### PR TITLE
Everyone's pyta_stats work, synced and appropriately divided

### DIFF
--- a/python_ta/reporters/stat_reporter.py
+++ b/python_ta/reporters/stat_reporter.py
@@ -1,11 +1,10 @@
-from sample_usage import pyta_stats as stats
 from .plain_reporter import PlainReporter
 
 
-# Report the results from pyta_stats.py
-
-
 class StatReporter(PlainReporter):
+
+    error_messages = []
+    style_messages = []
 
     def __init__(self, number_of_messages):
         """
@@ -26,15 +25,21 @@ class StatReporter(PlainReporter):
         @type level: str
         @rtype: None
         """
-        # self.sort_messages()
-        results = stats.stats_calculator(self._error_messages,
-                                         self._style_messages)
-        if stats.multi_files:
-            # write results to file
-            pass
-        else:   # meaning check_all was called with StatReporter by user
-            # print results to terminal/console
-            pass
+        StatReporter.error_messages.extend(self._error_messages)
+        StatReporter.style_messages.extend(self._style_messages)
 
     # to appease PyCharm's NotImplemented complaint
     _display = None
+
+
+def reset_messages():
+    """
+    Resets the class-level lists that hold the message lists to empty, so as to
+    avoid aggregating all files' messages in the StatReporter.
+    Called by pyta_statistics before every instantiation of StatReporter by
+    python_ta.check_all().
+
+    @rtype: None
+    """
+    StatReporter.error_messages = []
+    StatReporter.style_messages = []

--- a/sample_usage/pyta_stats.py
+++ b/sample_usage/pyta_stats.py
@@ -23,7 +23,7 @@ def pyta_statistics(directory):
     multi_files = True
     # walk directory, find every "file":
     # for each .py file visited, run python_ta.check_all(reporter=StatReporter)
-    # run stats_calculator
+    # store messages in global error_messages and style_messages
 
 
 def stats_calculator(error_msgs, style_msgs):
@@ -40,8 +40,7 @@ def stats_calculator(error_msgs, style_msgs):
     @rtype: dict
     """
     stats = {}
-    # collect all the errors and style errors from error_msgs, style_msgs, and
-    # have them in a dictionary with this form:
+    # have all the errors and style errors from error_msgs, style_msgs in a dictionary with this form:
     # {"Error or Style" + ": " + "msg.id " + "(msg.symbol)": int}
     # put this dict in to helper functions frequent_complaints(), percentage()
     # return the result of those functions in a dict with whatever form you like

--- a/sample_usage/pyta_stats.py
+++ b/sample_usage/pyta_stats.py
@@ -1,6 +1,6 @@
 import os
 import python_ta
-from python_ta.reporters.stat_reporter import StatReporter, error_messages, style_messages
+from python_ta.reporters.stat_reporter import StatReporter
 
 # keeps track of who called stat_calculator, to tell StatReporter how to print
 multi_files = False
@@ -32,9 +32,9 @@ def pyta_statistics(directory):
                 if file[-3:] == ".py":
                     python_ta.check_all(file, reporter=StatReporter)
                     # store all the msg objects of this student's files
-                    for msg in error_messages:
+                    for msg in StatReporter.error_messages:
                         all_errors.append(msg)
-                    for msg in style_messages:
+                    for msg in StatReporter.style_messages:
                         all_style.append(msg)
                     student_id = os.path.basename(os.path.normpath(root_str))
                     all_stats[student_id] = stats_calculator(all_errors,

--- a/sample_usage/pyta_stats.py
+++ b/sample_usage/pyta_stats.py
@@ -1,9 +1,7 @@
 import os
 import python_ta
 from python_ta.reporters.stat_reporter import StatReporter
-
-# keeps track of who called stat_calculator, to tell StatReporter how to print
-multi_files = False
+from .stats_analysis import *
 
 
 def pyta_statistics(directory):
@@ -42,55 +40,7 @@ def pyta_statistics(directory):
     return all_stats
 
 
-def stats_calculator(error_msgs, style_msgs): #these two things will be lists of Message objects
-    """
-    Analyse the given lists of error and style Message objects to aggregate
-    statistics on and return them in dictionary form.
-    Called by StatReporter.
-    Results dictionary format:
-    TODO
-    @param list error_msgs: Message objects for all errors found by linters
-    @param list style_msgs: Message objects for all style issues
-    @rtype: dict
-    """
-
-    # {msg.symbol + "(" + msg.object + ")": count}
-    all_msgs = error_msgs + style_msgs
-    # get dict of values {id:int, id2:int}
-    msgs_dict = calculator(all_msgs)
-    # sort into list of tuple, highest on top
-    freq_nums = frequent_complaints(msgs_dict)
-
-    total_errors = sum([msgs_dict[msg_id] for msg_id in msgs_dict])
-    # divide each value by total and round to two places
-    for message in msgs_dict:
-        msgs_dict[message] = (msgs_dict[message]/total_errors * 100).__round__(2)
-    perc_nums = frequent_complaints(msgs_dict)
-    stats = {'Most Frequent Messages In Numbers': freq_nums, 'Most Frequent Messages In Percentages': perc_nums}
-
-    return stats
-
-    # return dict = {"error" : int}
-
-
-def calculator(msgs):
-    """
-    Returns the number of errors for msgs.
-    :param list[Message] msgs: Message objects for all errors found by linters
-    :rtype: dict
-    """
-
-    included = []
-    msgs_dict = {}
-
-    for msg in msgs:
-        if msg.msg_id not in included:
-            msgs_dict[msg.msg_id + "(" + msg.symbol + ")"] = msgs.count(msg.msg_id)
-            included.append(msg.msg_id)
-    return msgs_dict
-
-
-def frequent_complaints(comp_dict, top=5):
+def frequent_messages(comp_dict, top=5):
     """
     Sort the errors in error_dict from the most frequent to least frequent in a
     list.
@@ -108,7 +58,7 @@ def frequent_complaints(comp_dict, top=5):
     most_frequently.reverse()
     # So the name of the error first and then the number of its occurrence.
     # return the top whatever number
-    if isinstance(top, int):
+    if isinstance(top, int) and top > 0:
         if top > len(most_frequently):
             top = len(most_frequently)
             return most_frequently[0:top]

--- a/sample_usage/stats_analysis.py
+++ b/sample_usage/stats_analysis.py
@@ -1,0 +1,50 @@
+from .pyta_stats import frequent_messages
+
+
+def stats_calculator(error_msgs, style_msgs):  # these two things will be lists of Message objects
+    """
+    Analyse the given lists of error and style Message objects to aggregate
+    statistics on and return them in dictionary form.
+    Called by StatReporter.
+    Results dictionary format:
+    TODO
+    @param list error_msgs: Message objects for all errors found by linters
+    @param list style_msgs: Message objects for all style issues
+    @rtype: dict
+    """
+
+    # {msg.symbol + "(" + msg.object + ")": count}
+    all_msgs = error_msgs + style_msgs
+    # get dict of values {id:int, id2:int}
+    msgs_dict = message_counter(all_msgs)
+    # sort into list of tuple, highest on top
+    freq_nums = frequent_messages(msgs_dict)
+
+    total_errors = sum([msgs_dict[msg_id] for msg_id in msgs_dict])
+    # divide each value by total and round to two places
+    for message in msgs_dict:
+        msgs_dict[message] = (msgs_dict[message]/total_errors * 100).__round__(2)
+    perc_nums = frequent_messages(msgs_dict)
+    stats = {'Most Frequent Messages In Numbers': freq_nums,
+             'Most Frequent Messages In Percentages': perc_nums}
+
+    return stats
+
+    # return dict = {"error" : int}
+
+
+def message_counter(msgs):
+    """
+    Returns the number of errors for msgs.
+    :param list[Message] msgs: Message objects for all errors found by linters
+    :rtype: dict
+    """
+
+    included = []
+    msgs_dict = {}
+
+    for msg in msgs:
+        if msg.msg_id not in included:
+            msgs_dict[msg.msg_id + "(" + msg.symbol + ")"] = msgs.count(msg.msg_id)
+            included.append(msg.msg_id)
+    return msgs_dict


### PR DESCRIPTION
Wendy copy-pasted Rebecca's `stats_calculator` work, as well as worked on her own `pyta_statistics`, so this merge has both of their work on `pyta_stats.py`. I also made some changes to `stat_reporter.py` and `pyta_stats.py` in accordance with the new design model. Finally, I split the actual stat calculators into a new file called `stats_analysis.py` that will be @rebeccakay 's file. 
Now we can all work on our own files and pull from each other's branches without worry of conflicts.
TODO: Possibly move `frequent_messages` (new name for `frequent_complaints`) into `stats_analysis.py` after @yunyiwendy is done working on it.
