### PR TITLE
Some HTML changes

### DIFF
--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -95,7 +95,7 @@ def _check(module_name='', reporter=ColorReporter, number_of_messages=5, level='
     source_lines = []
     with open(spec.origin) as f:
         source_lines = f.readlines()
-    current_reporter = reporter(number_of_messages, source_lines)
+    current_reporter = reporter(number_of_messages, source_lines, module_name)
 
     linter = lint.PyLinter(reporter=current_reporter)
     linter.load_default_plugins()

--- a/python_ta/reporters/TODO.md
+++ b/python_ta/reporters/TODO.md
@@ -23,8 +23,4 @@
 
 * Use javascript to expand and close the source code of each error messages.
 
-* `python_ta.checkall()` does not work on all examples. An unexpected error occurs and returns **Got unexpected field names: ['snippet']** when `python_ta.check_all("examples.pylint.W0631_undefined_loop_variable", reporter=HTMLReporter)` or `python_ta.check_all("examples.pylint.W0631_undefined_loop_variable")` is called. This is most likely because we added a new attribute, **snippet**, to **NewMessage** in the PlainReporter.
-
-* When the user opens the output.html for the first time, the date at the top right corner is the time when the output.html file is created. It, however, changes to the current time if the user refreshes the page. Find a way to prevent the date and time from changing after page refresh.
-
-* Show the file name.
+* Fix the file name in the header (use CSS `float` properly).

--- a/python_ta/reporters/color_reporter.py
+++ b/python_ta/reporters/color_reporter.py
@@ -26,8 +26,8 @@ no_hl = {"always-returning-in-a-loop",
 
 class ColorReporter(PlainReporter):
     # Override this method to add instance variables
-    def __init__(self, number_of_messages, source_lines=None):
-        super().__init__(number_of_messages, source_lines)
+    def __init__(self, number_of_messages, source_lines=None, module_name=''):
+        super().__init__(number_of_messages, source_lines, module_name)
         self._sorted_error_messages = {}
         self._sorted_style_messages = {}
 
@@ -172,8 +172,12 @@ class ColorReporter(PlainReporter):
                                         msg, end + 1, 'c')
 
                         result += code_snippet + '\n'
-                        messages[msg_id][i] = messages[msg_id][i]._replace(
-                                snippet=code_snippet)
+                        try:
+                            messages[msg_id][i] = msg._replace(snippet=code_snippet)
+                        except ValueError as e:
+                            # raise ValueError("Non-NewMessage message has "
+                            #                  "no 'snippet' attribute") from e
+                            pass
 
                 except AttributeError:
                     pass

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -1,6 +1,7 @@
 import os
 
 from jinja2 import Environment, FileSystemLoader
+from datetime import datetime
 
 from .color_reporter import ColorReporter
 
@@ -21,8 +22,13 @@ class HTMLReporter(ColorReporter):
         template = Environment(loader=FileSystemLoader(THIS_DIR)).get_template('templates/template.txt')
         output_path = THIS_DIR + '/templates/output.html'
 
+        # Date/time (24 hour time) format:
+        # Generated: ShortDay. ShortMonth. PaddedDay LongYear, Hour:Min:Sec
+        dt = "Generated: " + str(datetime.now().
+                                 strftime("%a. %b. %m %Y, %H:%M:%S"))
         with open(output_path, 'w') as f:
-            f.write(template.render(code=self._sorted_error_messages,
+            f.write(template.render(date_time=dt,
+                                    code=self._sorted_error_messages,
                                     style=self._sorted_style_messages))
         print("HTML Python TA report created. Please see output.html "
               "within pyta/python_ta/reporters/templates.")
@@ -79,11 +85,14 @@ class HTMLReporter(ColorReporter):
             snippet += space_count * '&nbsp;' + '...'
 
         else:
-            print("ERROR")
+            print("ERROR: unrecognised _add_line option")
         snippet += '<br/>'
         return snippet
 
     @staticmethod
     def _colourify(colour_class, text):
-        nbsp_text = text.replace(' ', '&nbsp;')
-        return '<span class="' + colour_class + '">' + nbsp_text + '</span>'
+        new_text = text.lstrip(' ')
+        space_count = len(text) - len(new_text)
+        new_text = new_text.replace(' ', '&nbsp;')
+        return ((space_count * '&nbsp;') + '<span class="' + colour_class + '">'
+                + new_text + '</span>')

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -28,6 +28,7 @@ class HTMLReporter(ColorReporter):
                                  strftime("%a. %b. %m %Y, %H:%M:%S"))
         with open(output_path, 'w') as f:
             f.write(template.render(date_time=dt,
+                                    mod_name=self._module_name,
                                     code=self._sorted_error_messages,
                                     style=self._sorted_style_messages))
         print("HTML Python TA report created. Please see output.html "

--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -53,12 +53,13 @@ ERROR_CHECKS = [
 
 
 class PlainReporter(BaseReporter):
-    def __init__(self, number_of_messages, source_lines=None):
+    def __init__(self, number_of_messages, source_lines=None, module_name=''):
         super().__init__()
         self._error_messages = []
         self._style_messages = []
         self._number_of_messages = number_of_messages
         self._source_lines = source_lines or []
+        self._module_name = module_name
 
     def handle_message(self, msg):
         """Handle a new message triggered on the current file."""

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -3,16 +3,21 @@
 	border-radius: 25px;
 	border: medium solid rgb(35, 35, 35);
 	background-color: rgb(130, 216, 245);
+	line-height: normal;
 	#padding: 10px;
 }
 body {
-
+    font-size: 100%;
+	font-family: "Lucida Sans", sans-serif;
+	line-height: 105%;
 	background-color: rgb(237, 251, 255);
 	text-align: center;
 }
 #date {
 	font-size: 12;
 	text-align: right;
+	padding-right: 10px;
+	margin: 5px;
 }
 .title {
 	margin: auto;
@@ -33,7 +38,6 @@ body {
 #core {
 	margin: auto;
 	text-align: left;
-	font-family: "Lucida Console", sans-serif;
 	font-size: 12;
 	border-radius: 25px;
 	border: thin solid rgb(122, 122, 122);
@@ -43,16 +47,14 @@ body {
 }
 
 #code {
+	font-size: 120%;
     color: rgb(255, 0, 0);
     font-weight: bold;
 }
 
 #style {
+	font-size: 120%;
     color: rgb(0, 0, 255);
-    font-weight: bold;
-}
-
-#bold {
     font-weight: bold;
 }
 
@@ -66,26 +68,31 @@ body {
     font-weight: bold;
 }
 
+.snippet {
+	font-family: "Lucida Console", monospace;
+	font-weight: normal;
+}
+
 .grey {
     color: rgb(119, 119, 120);
-    font-weight: normal;
-    font-family: "Lucida Console", monospace;
 }
 
 .gbold{
     color: rgb(90, 91, 92);
     font-weight: bold;
-    font-family: "Lucida Console", monospace;
 }
 
 .highlight {
     font-weight: bold;
     background-color: rgb(0, 255, 255);
-    font-family: "Lucida Console", monospace;
 }
 
 .black {
 	color: rgb(0, 0, 0);
-	font-weight: normal;
-	font-family: "Lucida Console", monospace;
+}
+
+#report_bug {
+	font-size: 75%;
+	#padding-top: 25px;
+	#color: black;
 }

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -13,9 +13,9 @@ body {
 	background-color: rgb(237, 251, 255);
 	text-align: center;
 }
-#date {
+#preheader {
 	font-size: 12;
-	text-align: right;
+	padding-left: 10px;
 	padding-right: 10px;
 	margin: 5px;
 }

--- a/python_ta/reporters/templates/template.txt
+++ b/python_ta/reporters/templates/template.txt
@@ -9,7 +9,15 @@
 			document.write("<p>" + Date() + "</p>")
 		</script>
 		-->
-		<div id="date"> {{ date_time }} </div>
+		<div id="preheader"> 
+			<!-- TODO: Needs to be fixed. -->
+			<p style="display: inline; text-align:left">
+				Module analysed: {{ mod_name }}
+			</p>
+			<span style="display: inline; text-align:right"> 
+				{{ date_time }}
+			</span>
+		</div>
 	
 	<div id="header">
 		<br/>
@@ -25,7 +33,7 @@
 		<div id="core">
 
 			<div id="code">
-			=== Code errors/forbidden usage (fix these right away!) ===
+				=== Code errors/forbidden usage (fix these right away!) ===
 			</div>
 			<u1>
 				{% for message in code %}

--- a/python_ta/reporters/templates/template.txt
+++ b/python_ta/reporters/templates/template.txt
@@ -1,80 +1,97 @@
 <html>
 <head>
     <link rel="stylesheet" type="text/css" href="stylesheet.css">
-<div id="date">
-<script type="text/javascript">
-document.write("<p>" + Date() + "</p>")
-</script>
-</div>
-<div id="header">
-<br/>
-<div class="title">
-PyTA Error Report
-</div>
-</div>
 </head>
-<br/>
 <body>
-<div id="inside">
-<p/>
-<div id="core">
+	
+		<!-- Constantly updated date:
+		<script type="text/javascript">
+			document.write("<p>" + Date() + "</p>")
+		</script>
+		-->
+		<div id="date"> {{ date_time }} </div>
+	
+	<div id="header">
+		<br/>
+		<div class="title">
+			PyTA Error Report
+		</div>
+	</div>
 
-<div id="code">
-=== Code errors/forbidden usage (fix these right away!) ===
-</div>
-<u1>
-    {% for message in code %}
-        <p><p><span class="code_id">{{ message }}</span>
-        <a href= "http://www.cs.toronto.edu/~david/pyta/&#35{{message}}">({{ code[message][0].symbol }})</a>
-        {{ code[message][0].obj }}
-        {% for indiv in code[message] %}
-        <div id="bold">
-        &nbsp;&nbsp;[Line {{ indiv.line }}] {{ indiv.msg }} <p/>
-        {% if indiv.snippet != '' %}
-            &nbsp;&nbsp;&nbsp;Your Code Starts Here: <p/>
-			{{ indiv.snippet }}
-        {% endif %} <br/>
-        </div>
-        {% endfor %}
-    {% endfor %}
-</u1>
+	<br/>
 
-<br/>
+	<div id="inside">
+		<p/>
+		<div id="core">
 
-<div id="style">
-=== Style/convention errors (fix these before submission) ===
-</div>
+			<div id="code">
+			=== Code errors/forbidden usage (fix these right away!) ===
+			</div>
+			<u1>
+				{% for message in code %}
+					<p/>
+					<p style="font-size: 110%">
+						<span class="code_id">{{ message }}</span>
+						<a href= "http://www.cs.toronto.edu/~david/pyta/&#35;{{message}}">({{ code[message][0].symbol }})</a>
+						{{ code[message][0].obj }}
+					</p>
+					{% for indiv in code[message] %}
+						<div style="font-weight:bold">
+						&nbsp;&nbsp;[Line {{ indiv.line }}] {{ indiv.msg }} <p/>
+						{% if indiv.snippet != '' %}
+							&nbsp;&nbsp;&nbsp;Your Code Starts Here: 
+							<p class="snippet">
+								{{ indiv.snippet }}
+							</p>
+						{% endif %}
+						</div>
+					{% endfor %}
+				{% endfor %}
+			</u1>
 
-<u1>
-    {% for message in style %}
-        <p><p><span class="style_id">{{ message }}</span>
-        <a href= "http://www.cs.toronto.edu/~david/pyta/&#35{{message}}">({{ style[message][0].symbol }})</a>
-        {{ style[message][0].obj }}
-        {% for indiv in style[message] %}
-        <div id="bold">
-        &nbsp;&nbsp;[Line {{ indiv.line }}] {{ indiv.msg }} <p/>
-        {% if indiv.snippet != '' %}
-            &nbsp;&nbsp;&nbsp;Your Code Starts Here: <p/>
-			{{ indiv.snippet }}
-		{% endif %} <br/>
-        </div>
-        {% endfor %}
-    {% endfor %}
-</u1>
+			<br/>
 
-</div>
-<a href="mailto:david@cs.toronto.edu">
-    <div id="report_bug" style="color:black">
-        Found a bug? Report it to Prof. Liu!
-    </div>
-</a>
-<p/>
-</div>
+			<div id="style">
+			=== Style/convention errors (fix these before submission) ===
+			</div>
+
+			<u1>
+				{% for message in style %}
+					<p/>
+					<p style="font-size: 110%">
+						<span class="style_id">{{ message }}</span>
+						<a href= "http://www.cs.toronto.edu/~david/pyta/&#35;{{message}}">({{ style[message][0].symbol }})</a>
+						{{ style[message][0].obj }}
+					</p>
+					{% for indiv in style[message] %}
+						<div style="font-weight:bold">
+						&nbsp;&nbsp;[Line {{ indiv.line }}] {{ indiv.msg }} <p/>
+						{% if indiv.snippet != '' %}
+							&nbsp;&nbsp;&nbsp;Your Code Starts Here:
+							<p class="snippet">
+								{{ indiv.snippet }}
+							</p>
+						{% endif %}
+						</div>
+					{% endfor %}
+				{% endfor %}
+			</u1>
+
+		</div>
+		<p/>
+		<a href="mailto:david@cs.toronto.edu">
+			<div id="report_bug">
+				Found a bug? Report it to Prof. Liu!
+			</div>
+		</a>
+		<p/>
+	</div>
 </body>
-<a href="http://www.cs.toronto.edu/~david/pyta/">
-<div style="position: relative">
-                <p style="position: relative; bottom: 0; width:100%; text-align: center"> <img src="pyta_logo_markdown.png" height="50"/>
-                </p>
-            </div>
-</a>
+<div style="position: relative">	
+	<p style="position: relative; bottom: 0; width:100%; text-align: center"> 
+		<a href="http://www.cs.toronto.edu/~david/pyta/" target="_blank">
+			<img src="pyta_logo_markdown.png" alt="PyTA logo" height="50"/>
+		</a>
+	</p>
+</div>
 </html>


### PR DESCRIPTION
Added `module_name` to the arguments of `PlainReporter` to enable passing the name to jinja to put in the HTML. Might need fixing (current string passed is the full relative module path). And HTML is better, but still needs work (particularly at the top where I added the module name). But the good news is that the time is now fixed at generation time, and we can play with the format if it's not legible enough.
Also, all HTML text is now `Lucida Sans` except for the title and the code snippets. Can be changed, but having a non-monospace font for the non-code snippet sections is nice.